### PR TITLE
Update Dockerfile to reduce size and build times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.6-slim-stretch
 
-RUN apt update
-RUN apt install -y python3-dev gcc
+RUN RUN apt-get update && apt-get install -y python3-dev gcc \
+    && rm -rf /var/lib/apt/lists/*
 
-ADD requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+ADD requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.6-slim-stretch
 
-RUN RUN apt-get update && apt-get install -y python3-dev gcc \
+RUN apt-get update && apt-get install -y python3-dev gcc \
     && rm -rf /var/lib/apt/lists/*
 
 ADD requirements.txt .
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app app/


### PR DESCRIPTION
This change follows Docker best practices around `apt` updates, and also prevents caching pip downloads, resulting in a faster build and significantly smaller images on Render.

These changes are already part of the fastai example for Render: https://github.com/render-examples/fastai-v3/blob/master/Dockerfile